### PR TITLE
should be awslogS not singular

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -228,7 +228,7 @@ def parse_event_source(event, key):
         return "cloudfront"
     if "kinesis" in key:
         return "kinesis"
-    if "awslog" in event:
+    if "awslogs" in event:
         return "cloudwatch"
     if "Records" in event and len(event["Records"]) > 0:
         if "s3" in event["Records"][0]:


### PR DESCRIPTION
now nicely showing 'cloudwatch' as source in Datadog Logs service for Lambda subscription stream

(part of Logs EU Beta under New10)