### PR TITLE
Add source auto detection for mysql and mariadb in RDS

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -216,7 +216,7 @@ def is_cloudtrail(key):
     return bool(match)
 
 def parse_event_source(event, key):
-    for source in ["lambda","elasticloadbalancing","redshift","cloudfront","kinesis", "mariadb","mysql","route53", "vpc", "rds"]:
+    for source in ["lambda","elasticloadbalancing","redshift","cloudfront","kinesis", "mariadb","mysql","apigateway", "route53", "vpc", "rds"]:
         if source in key:
             return source
     if is_cloudtrail(str(key)):

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -216,24 +216,11 @@ def is_cloudtrail(key):
     return bool(match)
 
 def parse_event_source(event, key):
-    if "lambda" in key:
-        return "lambda"
+    for source in ["lambda","elasticloadbalancing","redshift","cloudfront","kinesis", "mariadb","mysql","route53", "vpc", "rds"]:
+        if source in key:
+            return source
     if is_cloudtrail(str(key)):
         return "cloudtrail"
-    if "elasticloadbalancing" in key:
-        return "elb"
-    if "redshift" in key:
-        return "redshift"
-    if "cloudfront" in key:
-        return "cloudfront"
-    if "kinesis" in key:
-        return "kinesis"
-    if "mysql" in key:
-        return "mysql"
-    if "mariadb" in key:
-        return "mariadb"
-    if "rds" in key:
-        return "rds"
     if "awslogs" in event:
         return "cloudwatch"
     if "Records" in event and len(event["Records"]) > 0:

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -216,9 +216,11 @@ def is_cloudtrail(key):
     return bool(match)
 
 def parse_event_source(event, key):
-    for source in ["lambda", "elasticloadbalancing", "redshift", "cloudfront", "kinesis", "mariadb", "mysql", "apigateway", "route53", "vpc", "rds"]:
+    for source in ["lambda", "redshift", "cloudfront", "kinesis", "mariadb", "mysql", "apigateway", "route53", "vpc", "rds"]:
         if source in key:
             return source
+    if "elasticloadbalancing" in key:
+        return "elb"
     if is_cloudtrail(str(key)):
         return "cloudtrail"
     if "awslogs" in event:

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -228,6 +228,12 @@ def parse_event_source(event, key):
         return "cloudfront"
     if "kinesis" in key:
         return "kinesis"
+    if "mysql" in key:
+        return "mysql"
+    if "mariadb" in key:
+        return "mariadb"
+    if "rds" in key:
+        return "rds"
     if "awslogs" in event:
         return "cloudwatch"
     if "Records" in event and len(event["Records"]) > 0:

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -216,7 +216,7 @@ def is_cloudtrail(key):
     return bool(match)
 
 def parse_event_source(event, key):
-    for source in ["lambda","elasticloadbalancing","redshift","cloudfront","kinesis", "mariadb","mysql","apigateway", "route53", "vpc", "rds"]:
+    for source in ["lambda", "elasticloadbalancing", "redshift", "cloudfront", "kinesis", "mariadb", "mysql", "apigateway", "route53", "vpc", "rds"]:
         if source in key:
             return source
     if is_cloudtrail(str(key)):


### PR DESCRIPTION
AWS released a way to push MySQL and MariaDB logs to Cloudwatch. Therefore it is now possible to collect them with the lambda function and to automatically set the source.