### PR TITLE
added functionality for custom tags from DD_TAGS environment variable

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -40,6 +40,14 @@ cloudtrail_regex = re.compile('\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.js
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 
+# Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
+DD_TAGS = ""
+try:
+    DD_TAGS = os.environ['DD_TAGS'] + ","
+except Exception:
+    pass
+
+
 def lambda_handler(event, context):
     # Check prerequisites
     if ddApiKey == "<your_api_key>" or ddApiKey == "":
@@ -57,7 +65,7 @@ def lambda_handler(event, context):
     aws_meta["function_version"] = context.function_version
     aws_meta["invoked_function_arn"] = context.invoked_function_arn
     #Add custom tags here by adding new value with the following format "key1:value1, key2:value2"  - might be subject to modifications
-    metadata[DD_CUSTOM_TAGS] = "forwardername:" + context.function_name.lower()+ ",memorysize:"+ context.memory_limit_in_mb
+    metadata[DD_CUSTOM_TAGS] = DD_TAGS + "forwardername:" + context.function_name.lower() + ",memorysize:" + context.memory_limit_in_mb
 
     try:
         logs = generate_logs(event)


### PR DESCRIPTION
in order to pass tags like "prod", or "environment:prod" to all cloudwatch messages processed by the lambda, I've implemented similar functionality as for the DD docker container.
Using the DD_TAGS environment variable, which you can set in your CloudFormation or Terraform (like we do), as additional metadata["ddtags"].
Also minor whitespace on the '+'s.