### PR TITLE
Remove noisy log generated by the lambda itself

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -212,7 +212,8 @@ def send_entry(s, log_entry):
 
     # Send to Datadog
     str_entry = json.dumps(log_entry)
-    print(str_entry)
+    #For debugging purpose uncomment the following line
+    #print(str_entry)
     prefix = "%s " % ddApiKey
     return s.send((prefix + str_entry + "\n").encode("UTF-8"))
 


### PR DESCRIPTION
The lambda was printing each log entry it was sending. 
This was commented out and can be uncommented for debugging purpose.