### PR TITLE
Fixed ssl connection handling

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -36,12 +36,6 @@ metadata = {
     "ddsourcecategory": "aws",
 }
 
-
-try:
-    ssl_port = os.environ['DD_PORT']
-except Exception:
-    ssl_port = 10516
-    
 cloudtrail_regex = re.compile('\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.json.gz$', re.I)
 
 
@@ -49,6 +43,10 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_URL = os.getenv("DD_URL", default="lambda-intake.logs.datadoghq.com")
+try:
+    DD_PORT = os.environ['DD_PORT']
+except Exception:
+    DD_PORT = 10516
 
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
@@ -67,7 +65,7 @@ def lambda_handler(event, context):
         )
 
     # Attach Datadog's Socket
-    s = connect_to_datadog(DD_URL, ssl_port)
+    s = connect_to_datadog(DD_URL, DD_PORT)
 
     # Add the context to meta
     if "aws" not in metadata:
@@ -116,7 +114,7 @@ def safe_submit_log(s, log):
         send_entry(s, log)
     except Exception as e:
         # retry once
-        s = connect_to_datadog(DD_URL, ssl_port)
+        s = connect_to_datadog(DD_URL, DD_PORT)
         send_entry(s, log)
     return s
 

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -14,7 +14,6 @@ import ssl
 import re
 import StringIO
 import gzip
-from base64 import b64decode
 
 import boto3
 
@@ -23,7 +22,7 @@ import boto3
 ddApiKey = "<your_api_key>"
 try:
     ENCRYPTED = os.environ['DD_KMS_API_KEY']
-    ddApiKey = boto3.client('kms').decrypt(CiphertextBlob=b64decode(ENCRYPTED))['Plaintext']
+    ddApiKey = boto3.client('kms').decrypt(CiphertextBlob=base64.b64decode(ENCRYPTED))['Plaintext']
 except Exception:
     try:
         ddApiKey = os.environ['DD_API_KEY']

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -45,11 +45,7 @@ DD_PORT = os.environ.get('DD_PORT', 10516)
 
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
-DD_TAGS = ""
-try:
-    DD_TAGS = os.environ['DD_TAGS'] + ","
-except Exception:
-    pass
+DD_TAGS = os.environ.get('DD_TAGS', "")
 
 
 class DatadogConnection(object):
@@ -121,7 +117,16 @@ def lambda_handler(event, context):
         aws_meta["function_version"] = context.function_version
         aws_meta["invoked_function_arn"] = context.invoked_function_arn
         #Add custom tags here by adding new value with the following format "key1:value1, key2:value2"  - might be subject to modifications
-        metadata[DD_CUSTOM_TAGS] = DD_TAGS + "forwardername:" + context.function_name.lower() + ",memorysize:" + context.memory_limit_in_mb
+        dd_custom_tags_data = {
+            "forwardername": context.function_name.lower(),
+            "memorysize": context.memory_limit_in_mb
+            }
+        metadata[DD_CUSTOM_TAGS] = ",".join(
+            [
+                DD_TAGS,
+                ",".join(["{}:{}".format(k,v) for k,v in dd_custom_tags_data.iteritems()])
+            ]
+        )
 
         try:
             logs = generate_logs(event, context)

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -102,7 +102,7 @@ class DatadogConnection(object):
                 str_entry = ip_regex.sub("xxx.xxx.xxx.xx",str_entry)
             except Exception as e:
                 print('Unexpected exception while scrubbing logs: {} for event {}'.format(str(e), str_entry))
-            
+
         #For debugging purpose uncomment the following line
         #print(str_entry)
         prefix = "%s " % self.api_key
@@ -139,12 +139,13 @@ def lambda_handler(event, context):
             "forwardername": context.function_name.lower(),
             "memorysize": context.memory_limit_in_mb
             }
-        metadata[DD_CUSTOM_TAGS] = ",".join(
+        metadata[DD_CUSTOM_TAGS] = ",".join(filter(
+            None,
             [
                 DD_TAGS,
                 ",".join(["{}:{}".format(k,v) for k,v in dd_custom_tags_data.iteritems()])
             ]
-        )
+        ))
 
         try:
             logs = generate_logs(event, context)

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -41,10 +41,7 @@ DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
 DD_URL = os.getenv("DD_URL", default="lambda-intake.logs.datadoghq.com")
-try:
-    DD_PORT = os.environ['DD_PORT']
-except Exception:
-    DD_PORT = 10516
+DD_PORT = os.environ.get('DD_PORT', 10516)
 
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -9,7 +9,6 @@ import base64
 import json
 import urllib
 import boto3
-import time
 import os
 import socket
 import ssl

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import base64
 import json
 import urllib
-import boto3
 import os
 import socket
 import ssl
@@ -16,6 +15,8 @@ import re
 import StringIO
 import gzip
 from base64 import b64decode
+
+import boto3
 
 # Parameters
 # ddApiKey: Datadog API Key

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -36,7 +36,6 @@ metadata = {
     "ddsourcecategory": "aws",
 }
 
-host = os.getenv("DD_URL", default="lambda-intake.logs.datadoghq.com")
 
 try:
     ssl_port = os.environ['DD_PORT']
@@ -49,6 +48,7 @@ cloudtrail_regex = re.compile('\d+_CloudTrail_\w{2}-\w{4,9}-\d_\d{8}T\d{4}Z.+.js
 DD_SOURCE = "ddsource"
 DD_CUSTOM_TAGS = "ddtags"
 DD_SERVICE = "service"
+DD_URL = os.getenv("DD_URL", default="lambda-intake.logs.datadoghq.com")
 
 
 # Pass custom tags as environment variable, ensure comma separated, no trailing comma in envvar!
@@ -67,7 +67,7 @@ def lambda_handler(event, context):
         )
 
     # Attach Datadog's Socket
-    s = connect_to_datadog(host, ssl_port)
+    s = connect_to_datadog(DD_URL, ssl_port)
 
     # Add the context to meta
     if "aws" not in metadata:
@@ -116,7 +116,7 @@ def safe_submit_log(s, log):
         send_entry(s, log)
     except Exception as e:
         # retry once
-        s = connect_to_datadog(host, ssl_port)
+        s = connect_to_datadog(DD_URL, ssl_port)
         send_entry(s, log)
     return s
 


### PR DESCRIPTION
In current implementation, the scope of ssl connection `s` is too big and it is hard to track current connection state, I think.

In this PR, I made ssl connection handle class called `DatadogConnection`. Since that class implemented `__enter__` and `__exit__`, you can use create/close connection with `with` clause.