### PR TITLE
Reduce memory footprint of handlers

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -191,8 +191,6 @@ def awslogs_handler(event,context):
     ##default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
 
-    structured_logs = []
-
     # Send lines to Datadog
     for log in logs["logEvents"]:
         # Create structured object and send it
@@ -224,9 +222,7 @@ def awslogs_handler(event,context):
                     })
                     # 5. We add the function name as tag
                     metadata[DD_CUSTOM_TAGS] = metadata[DD_CUSTOM_TAGS] +",functionname:"+functioname
-        structured_logs.append(structured_line)
-
-    return structured_logs
+        yield structured_line
 
 #Handle Cloudwatch Events
 def cwevent_handler(event):
@@ -243,10 +239,7 @@ def cwevent_handler(event):
     ##default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
 
-    structured_logs = []
-    structured_logs.append(data)
-
-    return structured_logs
+    yield data
 
 # Handle Sns events
 def sns_handler(event):
@@ -254,14 +247,13 @@ def sns_handler(event):
     data = event
     # Set the source on the log
     metadata[DD_SOURCE] = parse_event_source(event, "sns")
-    structured_logs = []
 
     for ev in data['Records']:
         # Create structured object and send it
         structured_line = ev
-        structured_logs.append(structured_line)
+        yield structured_line
 
-    return structured_logs
+
 
 def send_entry(s, log_entry):
     # The log_entry can only be a string or a dict

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -39,14 +39,14 @@ metadata = {
 #Define the proxy endpoint to forward the logs to
 host = os.getenv("DD_URL", default="lambda-intake.logs.datadoghq.com")
 
-#Define the proxy port to forward the logs to 
+#Define the proxy port to forward the logs to
 try:
     ssl_port = os.environ['DD_PORT']
 except Exception:
     ssl_port = 10516
 
 #Scrubbing sensitive data
-#Option to redact all pattern that looks like an ip address    
+#Option to redact all pattern that looks like an ip address
 try:
     is_ipscrubbing = os.environ['REDACT_IP']
 except Exception:
@@ -154,13 +154,11 @@ def s3_handler(event):
     metadata[DD_SOURCE] = parse_event_source(event, key)
     ##default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
-    
+
     # Extract the S3 object
     response = s3.get_object(Bucket=bucket, Key=key)
     body = response['Body']
     data = body.read()
-
-    structured_logs = []
 
     # If the name has a .gz extension, then decompress the data
     if key[-3:] == '.gz':
@@ -172,15 +170,13 @@ def s3_handler(event):
         for event in cloud_trail['Records']:
             # Create structured object and send it
             structured_line = merge_dicts(event, {"aws": {"s3": {"bucket": bucket, "key": key}}})
-            structured_logs.append(structured_line)
+            yield structured_line
     else:
         # Send lines to Datadog
         for line in data.splitlines():
             # Create structured object and send it
             structured_line = {"aws": {"s3": {"bucket": bucket, "key": key}}, "message": line}
-            structured_logs.append(structured_line)
-
-    return structured_logs
+            yield structured_line
 
 
 # Handle CloudWatch logs
@@ -194,7 +190,7 @@ def awslogs_handler(event,context):
     metadata[DD_SOURCE] = parse_event_source(event, source)
     ##default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
-    
+
     structured_logs = []
 
     # Send lines to Datadog
@@ -246,7 +242,7 @@ def cwevent_handler(event):
         metadata[DD_SOURCE] = "cloudwatch"
     ##default service to source value
     metadata[DD_SERVICE] = metadata[DD_SOURCE]
-    
+
     structured_logs = []
     structured_logs.append(data)
 
@@ -281,14 +277,14 @@ def send_entry(s, log_entry):
 
     # Send to Datadog
     str_entry = json.dumps(log_entry)
-    
+
     #Scrub ip addresses if activated
     if is_ipscrubbing:
         try:
             str_entry = ip_regex.sub("xxx.xxx.xxx.xx",str_entry)
         except Exception as e:
             print('Unexpected exception while scrubbing logs: {} for event {}'.format(str(e), str_entry))
-            
+
     #For debugging purpose uncomment the following line
     #print(str_entry)
     prefix = "%s " % ddApiKey


### PR DESCRIPTION
This PR reduce the memory usage of the handlers by returning generator instead of the full array of dicts. 

It allows lazy loading of the lines and garbage collection of already sent lines. 

I tried with a 20Mo .gz file of 172Mo of raw logs. 

Resource usage went from 

```
Duration: 41705.09 ms	Billed Duration: 41800 ms Memory Size: 3008 MB	Max Memory Used: 2554 MB
```

to 

```
Duration: 32738.18 ms	Billed Duration: 32800 ms Memory Size: 3008 MB	Max Memory Used: 461 MB
```