### PR TITLE
Log Functionname tag lowercase

### DIFF
--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -299,7 +299,7 @@ def awslogs_handler(event, context):
                     structured_line = merge_dicts(log, {"lambda": {"arn": arn}})
                     # 5. We add the function name as tag
                     metadata[DD_CUSTOM_TAGS] = (
-                        metadata[DD_CUSTOM_TAGS] + ",functionname:" + functioname
+                        metadata[DD_CUSTOM_TAGS] + ",functionname:" + functioname.lower()
                     )
         yield structured_line
 

--- a/Log/lambda_function.py
+++ b/Log/lambda_function.py
@@ -288,7 +288,7 @@ def awslogs_handler(event, context):
         if metadata[DD_SOURCE] == "lambda":
             loggroupsplit = logs["logGroup"].split("/lambda/")
             if len(loggroupsplit) > 0:
-                functioname = loggroupsplit[1]
+                functioname = loggroupsplit[1].lower()
                 # 2. We split the arn of the forwarder to extract the prefix
                 arnsplit = context.invoked_function_arn.split("function:")
                 if len(arnsplit) > 0:
@@ -299,7 +299,7 @@ def awslogs_handler(event, context):
                     structured_line = merge_dicts(log, {"lambda": {"arn": arn}})
                     # 5. We add the function name as tag
                     metadata[DD_CUSTOM_TAGS] = (
-                        metadata[DD_CUSTOM_TAGS] + ",functionname:" + functioname.lower()
+                        metadata[DD_CUSTOM_TAGS] + ",functionname:" + functioname
                     )
         yield structured_line
 


### PR DESCRIPTION
The `functionname` tag that is set on metric is lowercase, so we need to do the same on the logs.
