### PR TITLE
SRE-862: Update the datadog provided lambda to work in our environment

### DIFF
--- a/rds_enhanced_monitoring/lambda_function.py
+++ b/rds_enhanced_monitoring/lambda_function.py
@@ -15,10 +15,10 @@ from StringIO import StringIO
 
 import boto3
 
-# retrieve datadog options from KMS
-KMS_ENCRYPTED_KEYS = os.environ['kmsEncryptedKeys']
-kms = boto3.client('kms')
-datadog_keys = json.loads(kms.decrypt(CiphertextBlob=b64decode(KMS_ENCRYPTED_KEYS))['Plaintext'])
+datadog_keys = {
+    "api_key": os.environ["DATADOG_API_KEY"],
+    "app_key": os.environ["DATADOG_APP_KEY"],
+}
 
 print 'INFO Lambda function initialized, ready to send metrics'
 


### PR DESCRIPTION
**Description**
Datadog provides a handy lambda to publish the RDS enhanced metrics. They use KMS to secure the API/app keys entered in the AWS console, so this changes their lambda to read from the environment in a way that we can inject the variables with hopper.

Note: this is now diverging from their lambda, and any futures updates may (or may not) be tricky to work with.